### PR TITLE
Allows default config file to be installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-location="$(readlink -f pwd)"
+location="$(readlink -f `pwd`)"
 
 mkdir -p $HOME/.config/bashful-thoughts
 cp $location/src/bashful_thoughts.conf $HOME/.config/bashful-thoughts/.bashful


### PR DESCRIPTION
When running `sh install.sh` it would throw the following error:

`$ cp: cannot stat ‘/home/snappershark/bashful-thoughts/pwd/src/bashful_thoughts.conf’: No such file or directory`

It seems I forgot to add back ticks to the sub command of `pwd`.

closes #4 